### PR TITLE
get_2D_current rápido

### DIFF
--- a/Tests/test_current.jl
+++ b/Tests/test_current.jl
@@ -1,28 +1,20 @@
 using BenchmarkTools
+
 const N = 2_000::Int64
 const J = (100::Int64,200::Int64)
 const Box = (0.0::Float64,1.0::Float64,0.0::Float64,1.0::Float64)
-const order = 5::Int64
-const par_grid =(N, Box, J, order)
-include("../aux_functions.jl")
+const order = Val(5)
+include("../aux_functions/aux_functions.jl")
 
-global u_r = Float64[]
-
+u_r = Float64[]
 for i in 1:N
-           u1 = Box[2]*rand()
-           u2 = Box[4]*rand()
-           u3 = (1.0 - 2.0*rand())
-           u4 = (1.0 - 2.0*rand())
-           global u_r = append!(u_r,[u1,u2,u3,u4])
-           #@show u_r
+    u1 = Box[2] * rand()
+    u2 = Box[4] * rand()
+    u3 = (1.0 - 2.0 * rand())
+    u4 = (1.0 - 2.0 * rand())
+    append!(u_r, [u1, u2, u3, u4])
+    #@show u_r
 end
 
 u = deepcopy(u_r)
-S1 = [[0.0::Float64,0.0::Float64] for i in 1:J[1], j in 1:J[2]]
-TS = zeros(Float64,(2,J...,nthreads()))
-
-par_threads = (par_grid, TS)
-
-@btime get_current_threads_2D!($u, $S1, $par_threads)
-
-
+@btime get_current_2D_trans(order, $N, $J, $Box, $u)

--- a/aux_functions/aux_functions_density_charge.jl
+++ b/aux_functions/aux_functions_density_charge.jl
@@ -339,3 +339,55 @@ function get_current_threads_2D!(u::Array{Float64,1}, S::Array{Float64,3}, par; 
 end
 
 
+static_bound(::Val{N}) where {N} = Int64(ceil(N / 2))
+
+function v_trans(::Val{D}, N, n0, u) where {D}
+  v = Matrix{Float64}(undef, N, D)
+  @threads for i in 1:N
+      @inbounds @views vtmp = p2v(u[i*2D-D+1:i*2D]) / n0
+      for d in 1:D
+          @inbounds v[i, d] = vtmp[d]
+      end
+  end
+  v
+end
+
+function sort_arrays_by_index(idx, y, v)
+  colperm = sortperm(collect(eachslice(idx; dims=2)))
+  idx[:, colperm], y[:, colperm], v[:, colperm]
+end
+
+function get_current_2D_trans(::Val{Order}, N::Integer, J::NTuple{2,Integer}, Box::NTuple{4,AbstractFloat}, u::Vector{Float64}; shift=0.0) :: Array{Float64} where {Order}
+  D::Int64 = 2
+  if D != length(J)
+    error("dimension mismatch")
+  end
+
+  n0 = N
+  bound = static_bound(Val(Order))
+
+
+  L = [(Box[2d] - Box[2d-1]) for d = 1:D]
+  r = [u[(i-1)*2D+d] for i = 1:N, d = 1:D]
+
+  idx, y = get_indices_and_y_trans(r, J, L, shift)
+  v = v_trans(Val(D), N, n0, u)
+
+  idx_sorted, y_sorted, v_sorted = sort_arrays_by_index(idx, y, v)
+
+  nlocals = Threads.nthreads()
+  local_results = zeros(Float64, J[1], J[2], D, nlocals)
+  @threads for i in 1:N
+      lid = Threads.threadid()
+      for l in (-bound):(bound+1)
+          s1 = Shape(order, -y_sorted[i, 1] + l)
+          for m in (-bound):(bound+1)
+              s2 = Shape(order, -y_sorted[i, 2] + m)
+              for d in 1:D
+                  @inbounds @fastmath local_results[mod1(idx_sorted[i, 1] + l, J[1]), mod1(idx_sorted[i, 2] + m, J[2]), d, lid] += s1 * s2 * v_sorted[i, d]
+              end
+          end
+      end
+  end
+  reduce(+, eachslice(local_results, dims=4))
+end

--- a/aux_functions/aux_functions_density_charge.jl
+++ b/aux_functions/aux_functions_density_charge.jl
@@ -306,21 +306,22 @@ function get_current_threads_2D!(u::Array{Float64,1}, S::Array{Float64,3}, par; 
   n0 = N
   # Evaluate number density.
   @threads for i in 1:N
-              #s = (i-1)*2D + 1
-              #r = view(u,s:s+D-1)
-              #p = view(u,s+D:s+2*D-1) # in the relativistic version we compute p instead of v
-      @inbounds v[:,threadid()] = p2v(u[i*2D - D + 1:i*2D]) / n0 # dividimos aquí para hacerlo más eficiente.
-              #s[threadid()] = (i-1)*2D + 1
-              #u_r[:,threadid()] = view(u,s[threadid()]:(s[threadid()]+D-1))
-              #j[:,threadid()], y[:,threadid()] = get_index_and_y!(j[:,threadid()], y[:,threadid()], u_r[:,threadid()],J , Box) 
-      @inbounds j[:,threadid()], y[:,threadid()] = get_index_and_y!(j[:,threadid()], y[:,threadid()], u[(i-1)*2D + 1:(i-1)*2D + D],J , Box) 
-      @inbounds y[:,threadid()] .= y[:,threadid()] .- shift # shift must be the same in all directions!
-              for l in (-bound):(bound+1) 
-                for m in (-bound):(bound+1)
-      @inbounds TS[:,mod1(j[1,threadid()] + l, J[1]), mod1(j[2,threadid()] + m, J[2]),threadid()] += Shape(order, -y[1,threadid()] + l) * Shape(order, -y[2,threadid()] + m)*v[:,threadid()]
-                end
-              end
-            end
+    #s = (i-1)*2D + 1
+    #r = view(u,s:s+D-1)
+    #p = view(u,s+D:s+2*D-1) # in the relativistic version we compute p instead of v
+    @views @inbounds v[:, threadid()] = p2v(u[i*2D-D+1:i*2D]) / n0 # dividimos aquí para hacerlo más eficiente.
+    #s[threadid()] = (i-1)*2D + 1
+    #u_r[:,threadid()] = view(u,s[threadid()]:(s[threadid()]+D-1))
+    #j[:,threadid()], y[:,threadid()] = get_index_and_y!(j[:,threadid()], y[:,threadid()], u_r[:,threadid()],J , Box) 
+    # @inbounds j[:, threadid()], y[:, threadid()] = get_index_and_y!(j[:, threadid()], y[:, threadid()], u[(i-1)*2D+1:(i-1)*2D+D], J, Box)
+    @inbounds @views get_index_and_y!(j[:, threadid()], y[:, threadid()], u[(i-1)*2D+1:(i-1)*2D+D], J, Box, shift)
+    for l in (-bound):(bound+1)
+      for m in (-bound):(bound+1)
+#        @inbounds TS[threadid(), :, mod1(j[1, threadid()] + l, J[1]), mod1(j[2, threadid()] + m, J[2])] += Shape(order, -y[1, threadid()] + l) * Shape(order, -y[2, threadid()] + m) * v[:, threadid()]
+        @views TS[:, mod1(j[1, threadid()] + l, J[1]), mod1(j[2, threadid()] + m, J[2]), threadid()] += Shape(order, -y[1, threadid()] + l) * Shape(order, -y[2, threadid()] + m) * v[:, threadid()]
+      end
+    end
+  end
 
   fill!(S,Float64(0.0))
   #S .= [0.0,0.0]

--- a/aux_functions/aux_functions_grid.jl
+++ b/aux_functions/aux_functions_grid.jl
@@ -68,10 +68,9 @@ get_index_and_y(0.4,2,1)
 dx = 0.5, j = 1, y = 0.4/0.5 = 0.8
 get_index_and_y(0.7,2,1) = j = 2, 0.2/0.5= 0.4
 """
-@inline function get_index_and_y(s,J,L)
-  y, int = modf((s/L*J + J)%J)
-  j = int + 1
-  j, y
+@inline function get_index_and_y(s, J, L, yshift=0.0)
+  y, j = modf((s / L * J + J) % J)
+  floor(Int64, j) + 1, y - yshift
 end
 
 """
@@ -84,11 +83,11 @@ y=zeros(3)
 get_index_and_y!(j,y,ss,Jt,Box)
 ([88, 88, 88], [0.4000000000000057, 0.39999999999997726, 0.4000000000000057])
 """
-@inline function get_index_and_y(r, J::Tuple,Box::Tuple)
+@inline function get_index_and_y(r, J::Tuple, Box::Tuple, yshift=0.0)
   j = zeros(Int64, length(J))
   y = zeros(length(J))
   for i in 1:length(J)
-    idx, y = get_index_and_y(r[i], J[i], Box[2i] - Box[2i-1])
+    idx, y = get_index_and_y(r[i], J[i], Box[2i] - Box[2i-1], yshift)
 
     # tmp = (r[i]/(Box[2i] - Box[2i-1])*J[i] + J[i])%J[i]
     # int = floor(Int,tmp)
@@ -119,9 +118,9 @@ get_index_and_y!(j,y,ss,Jt,Box)
   end
 end
 
-@inline function get_index_and_y!(j::AbstractArray{Int64,1}, y::AbstractArray{Float64,1}, r, J::Tuple,Box::Tuple) 
+@inline function get_index_and_y!(j::AbstractArray{Int64,1}, y::AbstractArray{Float64,1}, r, J::Tuple, Box::Tuple, yshift)
   for i in eachindex(J)
-    j[i], y[i] = get_index_and_y(r[i], J[i],Box[2i] - Box[2i-1])
+    j[i], y[i] = get_index_and_y(r[i], J[i], Box[2i] - Box[2i-1], yshift)
     # y[i] =  (r[i]/(Box[2i] - Box[2i-1])*J[i] + J[i])%J[i]
     # j[i] = floor(Int,y[i]) + 1
     # y[i] = (y[i]%1)

--- a/aux_functions/aux_functions_grid.jl
+++ b/aux_functions/aux_functions_grid.jl
@@ -99,6 +99,21 @@ get_index_and_y!(j,y,ss,Jt,Box)
   j, y
 end
 
+@inline function get_indices_and_y_trans(r, sz, L, yshift=0.0)
+  N = size(r)[1]
+  D = size(r)[2]
+  idx = Matrix{Int64}(undef, N, D)
+  y = Matrix{Float64}(undef, N, D)
+  for d = 1:D
+    @threads for i = 1:N
+      @inbounds tmp = (r[i, d] / L[d] * sz[d] + sz[d]) % sz[d]
+      idx[i, d] = floor(Int64, tmp) + 1
+      y[i, d] = (tmp % 1) - yshift
+    end
+  end
+  idx, y
+end
+
 """
 same as before, but for an arbitrary box and dimension.
 Jt = (100, 200, 200)

--- a/aux_functions/aux_functions_grid.jl
+++ b/aux_functions/aux_functions_grid.jl
@@ -68,12 +68,10 @@ get_index_and_y(0.4,2,1)
 dx = 0.5, j = 1, y = 0.4/0.5 = 0.8
 get_index_and_y(0.7,2,1) = j = 2, 0.2/0.5= 0.4
 """
-function get_index_and_y(s,J,L)
-  s = (s/L*J + J)%J
-  j = floor(Int,s) + 1
-  #j = convert(Int64,s) + 1
-  y = (s%1)
-  return j, y
+@inline function get_index_and_y(s,J,L)
+  y, int = modf((s/L*J + J)%J)
+  j = int + 1
+  j, y
 end
 
 """
@@ -86,13 +84,48 @@ y=zeros(3)
 get_index_and_y!(j,y,ss,Jt,Box)
 ([88, 88, 88], [0.4000000000000057, 0.39999999999997726, 0.4000000000000057])
 """
-function get_index_and_y!(j::Array{Int64,1}, y::Array{Float64,1}, r, J::Tuple,Box::Tuple) 
+@inline function get_index_and_y(r, J::Tuple,Box::Tuple)
+  j = zeros(Int64, length(J))
+  y = zeros(length(J))
   for i in 1:length(J)
+    idx, y = get_index_and_y(r[i], J[i], Box[2i] - Box[2i-1])
+
+    # tmp = (r[i]/(Box[2i] - Box[2i-1])*J[i] + J[i])%J[i]
+    # int = floor(Int,tmp)
+    # j[i], y[i] = int + 1, tmp - int
+
+    # y[i], int = modf((r[i]/(Box[2i] - Box[2i-1])*J[i] + J[i])%J[i])
+    # j[i] = convert(Int, int) + 1
+  end
+  j, y
+end
+
+"""
+same as before, but for an arbitrary box and dimension.
+Jt = (100, 200, 200)
+Box = (0.0, 10, 0.0, 20, -20.0, 0.0)
+ss = [8.74, 8.74, -11.26]
+j=[1,1,1]
+y=zeros(3)
+get_index_and_y!(j,y,ss,Jt,Box)
+([88, 88, 88], [0.4000000000000057, 0.39999999999997726, 0.4000000000000057])
+"""
+@inline function get_index_and_y_old!(j::AbstractArray{Int64,1}, y::AbstractArray{Float64,1}, r, J::Tuple,Box::Tuple) 
+  for i in 1:length(J)
+    # j[i], y[i] = get_index_and_y(r[i], J[i],Box[2i] - Box[2i-1])
     y[i] =  (r[i]/(Box[2i] - Box[2i-1])*J[i] + J[i])%J[i]
     j[i] = floor(Int,y[i]) + 1
     y[i] = (y[i]%1)
   end
-  return j[:], y[:]
+end
+
+@inline function get_index_and_y!(j::AbstractArray{Int64,1}, y::AbstractArray{Float64,1}, r, J::Tuple,Box::Tuple) 
+  for i in eachindex(J)
+    j[i], y[i] = get_index_and_y(r[i], J[i],Box[2i] - Box[2i-1])
+    # y[i] =  (r[i]/(Box[2i] - Box[2i-1])*J[i] + J[i])%J[i]
+    # j[i] = floor(Int,y[i]) + 1
+    # y[i] = (y[i]%1)
+  end
 end
 
 function get_index_and_y_alt!(j::Array{Int64,1}, y::Array{Float64,1}, r, J::Tuple,Box::Tuple)

--- a/aux_functions/aux_functions_shapes.jl
+++ b/aux_functions/aux_functions_shapes.jl
@@ -65,3 +65,53 @@ While the orders of W goes from 0 to 5
 @inline function Shape(order::Int, y::Float64)
   return W(order - 1, y)
 end
+
+
+@inline function W(::Val{0}, y::T)::T where {T<:AbstractFloat}
+  y = abs(y)
+  (y <= 0.5) ? 1.0 : 0.0
+end
+
+@inline function W(::Val{1}, y::T)::T where {T<:AbstractFloat}
+  y = abs(y)
+  (y <= 1.0) ? 1.0 - y : 0.0
+end
+
+@inline function W(::Val{2}, y::T)::T where {T<:AbstractFloat}
+  y = abs(y)
+  #return (y <= 1/2) ? 3/4 - y^2  : (((y > 1/2) && (y <= 3/2)) ? (3 - 2*y)^2 / 8 : 0)
+  (y <= 0.5) ? 0.75 - y^2 : (((y <= 1.5)) ? (3.0 - 2.0 * y)^2 / 8.0 : 0.0)
+end
+
+@inline function W(::Val{3}, y::T)::T where {T<:AbstractFloat}
+  y = abs(y)
+  #return (y <= 1) ? 2/3 - y^2 + y^3 / 2 : (((y > 1) && (y <= 2)) ? (2 - y)^3 / 6 : 0)
+  (y <= 1.0) ? 2.0 / 3.0 - y^2 + y^3 / 2.0 : ((y <= 2) ? (2 - y)^3 / 6.0 : 0.0)
+end
+
+@inline function W(::Val{4}, y::T)::T where {T<:AbstractFloat}
+  y = abs(y)
+  #return (y <= 1/2) ? 115/192 - 5y^2/8 + y^4/4 : (((y > 1/2) && (y <= 3/2)) ? (55 + 20y -120y^2 + 80y^3 - 16y^4)/96 : (((y > 3/2) && (y < 5/2)) ? (5 - 2y)^4/384 : 0))
+  (y <= 0.5) ? 115 / 192 - 5y^2 / 8 + y^4 / 4 : (((y <= 3 / 2)) ? (55 + 20y - 120y^2 + 80y^3 - 16y^4) / 96 : (((y < 5 / 2)) ? (5 - 2y)^4 / 384 : 0.0))
+end
+
+@inline function W(::Val{5}, y::T)::T where {T<:AbstractFloat}
+  y = abs(y)
+  #return (y <= 1) ? 11/20 - y^2/2 + y^4/4 - y^5/12 : (((y > 1) && (y <= 2)) ? 17/40 + 5y/8 - 7y^2/4 + 5y^3/4 - 3y^4/8 + y^5/24 : (((y > 2) && (y < 3)) ? (3 - y)^5/120 : 0))
+  (y <= 1) ? 11 / 20 - y^2 / 2 + y^4 / 4 - y^5 / 12 : (((y <= 2)) ? 17 / 40 + 5y / 8 - 7y^2 / 4 + 5y^3 / 4 - 3y^4 / 8 + y^5 / 24 : (((y < 3)) ? (3 - y)^5 / 120 : 0.0))
+end
+
+"""
+Shape functions are W functions of an order less.
+The dx in the Appendix is added when used so as not to carry dx all over.
+So this definition DIFFERS FROM THE PAPER BY A DX!
+They have support on -order/2 =< y =< order/2
+The orders goes from 1 to 6 (order zero is not defined)
+While the orders of W goes from 0 to 5
+"""
+@inline Shape(::Val{1}, y::AbstractFloat) = W(Val(0), y)
+@inline Shape(::Val{2}, y::AbstractFloat) = W(Val(1), y)
+@inline Shape(::Val{3}, y::AbstractFloat) = W(Val(2), y)
+@inline Shape(::Val{4}, y::AbstractFloat) = W(Val(3), y)
+@inline Shape(::Val{5}, y::AbstractFloat) = W(Val(4), y)
+@inline Shape(::Val{6}, y::AbstractFloat) = W(Val(5), y)

--- a/aux_functions/aux_functions_shapes.jl
+++ b/aux_functions/aux_functions_shapes.jl
@@ -2,26 +2,26 @@
 Derivatives of shape functions.
 They have support for -(order+1)/2 =< y =< (order+1)/2
 """
-@inline function W(order::Int,y::Float64)
+@inline function W(order::Int, y::Float64)
   #y = norm(y)
   y = abs(y)
   if order == 0
-    return  (y <= 1/2) ? 1 : 0
-  elseif order ==1
-    return  (y <= 1) ? 1 - y : 0
+    return (y <= 1 / 2) ? 1 : 0
+  elseif order == 1
+    return (y <= 1) ? 1 - y : 0
   elseif order == 2
     #return (y <= 1/2) ? 3/4 - y^2  : (((y > 1/2) && (y <= 3/2)) ? (3 - 2*y)^2 / 8 : 0)
-    return (y <= 1/2) ? 3/4 - y^2  : (((y <= 3/2)) ? (3 - 2*y)^2 / 8 : 0)
+    return (y <= 1 / 2) ? 3 / 4 - y^2 : (((y <= 3 / 2)) ? (3 - 2 * y)^2 / 8 : 0)
   elseif order == 3
     #return (y <= 1) ? 2/3 - y^2 + y^3 / 2 : (((y > 1) && (y <= 2)) ? (2 - y)^3 / 6 : 0)
-    return (y <= 1) ? 2/3 - y^2 + y^3 / 2 : ((y <= 2) ? (2 - y)^3 / 6 : 0)
+    return (y <= 1) ? 2 / 3 - y^2 + y^3 / 2 : ((y <= 2) ? (2 - y)^3 / 6 : 0)
   elseif order == 4
     #return (y <= 1/2) ? 115/192 - 5y^2/8 + y^4/4 : (((y > 1/2) && (y <= 3/2)) ? (55 + 20y -120y^2 + 80y^3 - 16y^4)/96 : (((y > 3/2) && (y < 5/2)) ? (5 - 2y)^4/384 : 0))
-    return (y <= 1/2) ? 115/192 - 5y^2/8 + y^4/4 : (((y <= 3/2)) ? (55 + 20y -120y^2 + 80y^3 - 16y^4)/96 : (((y < 5/2)) ? (5 - 2y)^4/384 : 0))
+    return (y <= 1 / 2) ? 115 / 192 - 5y^2 / 8 + y^4 / 4 : (((y <= 3 / 2)) ? (55 + 20y - 120y^2 + 80y^3 - 16y^4) / 96 : (((y < 5 / 2)) ? (5 - 2y)^4 / 384 : 0))
   elseif order == 5
     #return (y <= 1) ? 11/20 - y^2/2 + y^4/4 - y^5/12 : (((y > 1) && (y <= 2)) ? 17/40 + 5y/8 - 7y^2/4 + 5y^3/4 - 3y^4/8 + y^5/24 : (((y > 2) && (y < 3)) ? (3 - y)^5/120 : 0))
-    return (y <= 1) ? 11/20 - y^2/2 + y^4/4 - y^5/12 : (((y <= 2)) ? 17/40 + 5y/8 - 7y^2/4 + 5y^3/4 - 3y^4/8 + y^5/24 : (((y < 3)) ? (3 - y)^5/120 : 0))
-  
+    return (y <= 1) ? 11 / 20 - y^2 / 2 + y^4 / 4 - y^5 / 12 : (((y <= 2)) ? 17 / 40 + 5y / 8 - 7y^2 / 4 + 5y^3 / 4 - 3y^4 / 8 + y^5 / 24 : (((y < 3)) ? (3 - y)^5 / 120 : 0))
+
   else
     error("order = $order not yet implemented ")
   end
@@ -31,24 +31,24 @@ end
 """
 Alternative definition
 """
-function W_alt(order::Int,y::Float64)
+function W_alt(order::Int, y::Float64)
   y = abs(y)
   if order == 0
-    return  (y > 1/2) ? 0 : 1
-  elseif order ==1
-    return  (y > 1) ? 0 : 1 - y 
+    return (y > 1 / 2) ? 0 : 1
+  elseif order == 1
+    return (y > 1) ? 0 : 1 - y
   elseif order == 2
     #return (y <= 1/2) ? 3/4 - y^2  : (((y > 1/2) && (y <= 3/2)) ? (3 - 2*y)^2 / 8 : 0)
-    return (y > 3/2) ? 0 : (((y > 1/2) && (y <= 3/2)) ? (3 - 2*y)^2 / 8 : 3/4 - y^2)
+    return (y > 3 / 2) ? 0 : (((y > 1 / 2) && (y <= 3 / 2)) ? (3 - 2 * y)^2 / 8 : 3 / 4 - y^2)
   elseif order == 3
     #return (y <= 1) ? 2/3 - y^2 + y^3 / 2 : (((y > 1) && (y <= 2)) ? (2 - y)^3 / 6 : 0)
-    return (y > 2) ? 0 : (((y > 1) && (y <= 2)) ? (2 - y)^3 / 6 : 2/3 - y^2 + y^3 / 2)
+    return (y > 2) ? 0 : (((y > 1) && (y <= 2)) ? (2 - y)^3 / 6 : 2 / 3 - y^2 + y^3 / 2)
   elseif order == 4
     #return (y <= 1/2) ? 115/192 - 5y^2/8 + y^4/4 : (((y > 1/2) && (y <= 3/2)) ? (55 + 20y -120y^2 + 80y^3 - 16y^4)/96 : (((y > 3/2) && (y < 5/2)) ? (5 - 2y)^4/384 : 0))
-    return (y > 5/2) ? 0 : (((y > 3/2) && (y < 5/2)) ? (5 - 2y)^4/384 : (((y > 1/2) && (y <= 3/2)) ? (55 + 20y -120y^2 + 80y^3 - 16y^4)/96 : 115/192 - 5y^2/8 + y^4/4))
+    return (y > 5 / 2) ? 0 : (((y > 3 / 2) && (y < 5 / 2)) ? (5 - 2y)^4 / 384 : (((y > 1 / 2) && (y <= 3 / 2)) ? (55 + 20y - 120y^2 + 80y^3 - 16y^4) / 96 : 115 / 192 - 5y^2 / 8 + y^4 / 4))
   elseif order == 5
     #return (y <= 1) ? 11/20 - y^2/2 + y^4/4 - y^5/12 : (((y > 1) && (y <= 2)) ? 17/40 + 5y/8 - 7y^2/4 + 5y^3/4 - 3y^4/8 + y^5/24 : (((y > 2) && (y < 3)) ? (3 - y)^5/120 : 0))
-    return (y > 3) ? 0 : (((y > 2) && (y < 3)) ? (3 - y)^5/120 : (((y > 1) && (y <= 2)) ? 17/40 + 5y/8 - 7y^2/4 + 5y^3/4 - 3y^4/8 + y^5/24 : 11/20 - y^2/2 + y^4/4 - y^5/12))
+    return (y > 3) ? 0 : (((y > 2) && (y < 3)) ? (3 - y)^5 / 120 : (((y > 1) && (y <= 2)) ? 17 / 40 + 5y / 8 - 7y^2 / 4 + 5y^3 / 4 - 3y^4 / 8 + y^5 / 24 : 11 / 20 - y^2 / 2 + y^4 / 4 - y^5 / 12))
   else
     error("order = $order not yet implemented ")
   end
@@ -62,6 +62,6 @@ They have support on -order/2 =< y =< order/2
 The orders goes from 1 to 6 (order zero is not defined)
 While the orders of W goes from 0 to 5
 """
-@inline function Shape(order::Int,y::Float64) 
-  return W(order - 1,y)
+@inline function Shape(order::Int, y::Float64)
+  return W(order - 1, y)
 end


### PR DESCRIPTION
Agregado `get_current_2D_trans` que dispone las matrices con la D al final (que técnicamente no es transpuesta, bue). Escala relativamente bien para N grande, se puede paralelizar alguna que otra cosa más pero no creo que se justifique.

Por lo que estuve probando anda bien, pero cada tanto devuelve resultados distintos al código original para muchos hilos. Creo que es numérica la diferencia porque otra cosa no le encuentro.