### PR TITLE
Actualizaciones de get_current_2D_trans

### DIFF
--- a/aux_functions/aux_functions_density_charge.jl
+++ b/aux_functions/aux_functions_density_charge.jl
@@ -343,13 +343,17 @@ static_bound(::Val{N}) where {N} = Int64(ceil(N / 2))
 
 function v_trans(::Val{D}, N, n0, u) where {D}
   v = Matrix{Float64}(undef, N, D)
+  v_trans!(Val(D), v, N, n0, u)
+  v
+end
+
+function v_trans!(::Val{D}, v, N, n0, u) where {D}
   @threads for i in 1:N
       @inbounds @views vtmp = p2v(u[i*2D-D+1:i*2D]) / n0
       for d in 1:D
           @inbounds v[i, d] = vtmp[d]
       end
   end
-  v
 end
 
 function sort_arrays_by_index(idx, y, v)

--- a/aux_functions/aux_functions_density_charge.jl
+++ b/aux_functions/aux_functions_density_charge.jl
@@ -396,16 +396,16 @@ function get_current_2D_trans!(::Val{Order}, result :: Array{Float64, 3}, storag
   nlocals = Threads.nthreads()
   local_results .= 0.0
   @threads for i in 1:N
-      lid = Threads.threadid()
+    lid = Threads.threadid()
+    for m in (-bound):(bound+1)
+      sm = Shape(Val(Order), -y[i, 2] + m)
       for l in (-bound):(bound+1)
-          s1 = Shape(Val(Order), -y[i, 1] + l)
-          for m in (-bound):(bound+1)
-              s2 = Shape(Val(Order), -y[i, 2] + m)
-              for d in 1:D
-                  @fastmath @inbounds local_results[mod1(idx[i, 1] + l, J[1]), mod1(idx[i, 2] + m, J[2]), d, lid] += s1 * s2 * v[i, d]
-              end
-          end
+        sl = Shape(Val(Order), -y[i, 1] + l)
+        for d in 1:D
+          @fastmath @inbounds local_results[mod1(idx[i, 1] + l, J[1]), mod1(idx[i, 2] + m, J[2]), d, lid] += sm * sl * v[i, d]
+        end
       end
+    end
   end
   result .= reduce(+, eachslice(local_results, dims=4))
 end

--- a/aux_functions/aux_functions_density_charge.jl
+++ b/aux_functions/aux_functions_density_charge.jl
@@ -289,7 +289,7 @@ The output is an array of type (2,J1,J2). Checked and working OK against the oth
 function get_current_threads_2D!(u::Array{Float64,1}, S::Array{Float64,3}, par; shift=0.0) #WITH DIFFERENT LAYOUT
   #par_grid, Tn, j, y = par # no vale la pena en cuanto a tiempo ni memoria
   par_grid, TS = par
-  N, J, Box, order = par_grid
+  N, Box, J, order = par_grid
   D = 2::Int64
   bound = Int64(ceil(order/2))
   if D != length(J) 

--- a/aux_functions/aux_functions_grid.jl
+++ b/aux_functions/aux_functions_grid.jl
@@ -99,11 +99,9 @@ get_index_and_y!(j,y,ss,Jt,Box)
   j, y
 end
 
-@inline function get_indices_and_y_trans(r, sz, L, yshift=0.0)
+@inline function get_indices_and_y_trans!(idx, y, r, sz, L, yshift=0.0)
   N = size(r)[1]
   D = size(r)[2]
-  idx = Matrix{Int64}(undef, N, D)
-  y = Matrix{Float64}(undef, N, D)
   for d = 1:D
     @threads for i = 1:N
       @inbounds tmp = (r[i, d] / L[d] * sz[d] + sz[d]) % sz[d]
@@ -111,6 +109,14 @@ end
       y[i, d] = (tmp % 1) - yshift
     end
   end
+end
+
+@inline function get_indices_and_y_trans(r, sz, L, yshift=0.0)
+  N = size(r)[1]
+  D = size(r)[2]
+  idx = Matrix{Int64}(undef, N, D)
+  y = Matrix{Float64}(undef, N, D)
+  get_indices_and_y_trans!(idx, y, r, sz, L, yshift)
   idx, y
 end
 


### PR DESCRIPTION
Agregué versiones de casi todo el código nuevo que modifican los arreglos que se pasan por parámetros. No tiene mucho sentido porque en performance anda igual o un poco peor que el código anterior que hace allocations nuevas para todo, principalmente porque `reduce(+, eachslice(local_results, dims=4))` hace algo de magia más rápida que sumar a mano.

Para usar la función nueva `get_current_2D_trans!` hay que crear un `Current2DTransStorage` que tiene todos los arreglos temporales que hacen falta para correr. `get_current_2D_trans` (sin `!`) muestra cómo usarlo.

Estoy viendo que hay una forma de hacer mejor esto (construir un callable en vez de un struct, que después se puede pasar llamar como si fuera una función), pero me va a tomar algo de tiempo pasarlo en limpio.