### PR TITLE
Optimizaciones a RHS_D_slim e Interpolate_EBv_1_slim

### DIFF
--- a/Tests/test_speed_RHS.jl
+++ b/Tests/test_speed_RHS.jl
@@ -208,12 +208,12 @@ val_order = Val(order)
 
 RHS_D(du_ref,u,p_RHS_D); # here we save the output before changes
 #RHS_D_opt(du,u,p_RHS_D);
-RHS_D_slim(val_order,du,u,p_RHS_D);
+RHS_D_slim!(val_order,du,u,p_RHS_D);
 #@profile RHS_D_slim(du,u,p_RHS_D);
 #VSCodeServer.@profview RHS_D_slim(du,u,p_RHS_D);
 
 @show norm(du_ref - du)
-@btime RHS_D_slim($val_order,$du,$u,$p_RHS_D);
+@btime RHS_D_slim!($val_order,$du,$u,$p_RHS_D);
 
 
 # N = 10^5

--- a/Tests/test_speed_RHS.jl
+++ b/Tests/test_speed_RHS.jl
@@ -204,14 +204,16 @@ else
     p_RHS_D = (N, J, Box_x, order, n, S, du, get_density_2D!, get_current_rel_2D!, Interpolate_EBv_1, Dx, Δx, σx, Dy, Δy, σy, maxwell, dissipation) ;
 end
 
+val_order = Val(order)
+
 RHS_D(du_ref,u,p_RHS_D); # here we save the output before changes
 #RHS_D_opt(du,u,p_RHS_D);
-RHS_D_slim(du,u,p_RHS_D);
+RHS_D_slim(val_order,du,u,p_RHS_D);
 #@profile RHS_D_slim(du,u,p_RHS_D);
 #VSCodeServer.@profview RHS_D_slim(du,u,p_RHS_D);
 
 @show norm(du_ref - du)
-@btime RHS_D_slim($du,$u,$p_RHS_D);
+@btime RHS_D_slim($val_order,$du,$u,$p_RHS_D);
 
 
 # N = 10^5

--- a/aux_functions/aux_functions_Interpolate.jl
+++ b/aux_functions/aux_functions_Interpolate.jl
@@ -141,12 +141,12 @@ Interpolate function for the whole of E + v x B
   end
 end
 
-@inline function Interpolate_EBv_1_slim(order::Int64, E::Array{Float64,3}, B::Array{Float64,2}, v::Array{Float64,1}, j, y , J::NTuple, Box::NTuple)
+@inline function Interpolate_EBv_1_slim(::Val{Order}, E::Array{Float64,3}, B::Array{Float64,2}, v::Array{Float64,1}, j, y , J::NTuple, Box::NTuple) where {Order}
   #stencil = order÷2
-  stencil = Int64(ceil((order+1)/2))
+  stencil = Int64(ceil((Order+1)/2))
   D = length(J)
   EBv = Array{Float64,1}(undef,2)
-  val_order = Val(order)
+  val_order = Val(Order)
   if D==1
     #j, y = get_index_and_y(x,J[1],Box[2]-Box[1])
     vi = 0.0

--- a/aux_functions/aux_functions_Interpolate.jl
+++ b/aux_functions/aux_functions_Interpolate.jl
@@ -162,16 +162,15 @@ end
     #j, y = get_index_and_y!(j,y,x,J,Box)
     #j, y = get_index_and_y!(x,J,Box)
     vi = zeros(2)
-    ws = 0.0
     @inbounds for m in (-stencil):(stencil +1)
-      ws = W(val_order, -y[2] + m)
+      w2 = W(val_order, -y[2] + m)
       j2 = mod1(j[2]+m,J[2])
       @inbounds for l in (-stencil):(stencil +1)
-        ws *= W(val_order, -y[1] + l)
+        w1 = W(val_order, -y[1] + l)
         j1 = mod1(j[1]+l,J[1])
         EBv[1] = E[1,j1,j2] - v[2]*B[j1,j2]
         EBv[2] = E[2,j1,j2] + v[1]*B[j1,j2]
-        vi += EBv * ws
+        vi += EBv * w2 * w1
       end
     end
     return vi

--- a/aux_functions/aux_functions_Interpolate.jl
+++ b/aux_functions/aux_functions_Interpolate.jl
@@ -163,18 +163,18 @@ end
     #j, y = get_index_and_y!(x,J,Box)
     vi = zeros(2)
     ws = 0.0
-    #=@fastmath=# for l in (-stencil):(stencil +1)
-      ws = W(val_order, -y[1] + l)
-      j1 = mod1(j[1]+l,J[1])
-      @inbounds for m in (-stencil):(stencil +1)
-        ws *= W(val_order, -y[2] + m)
-        j2 = mod1(j[2]+m,J[2])
+    @inbounds for m in (-stencil):(stencil +1)
+      ws = W(val_order, -y[2] + m)
+      j2 = mod1(j[2]+m,J[2])
+      @inbounds for l in (-stencil):(stencil +1)
+        ws *= W(val_order, -y[1] + l)
+        j1 = mod1(j[1]+l,J[1])
         EBv[1] = E[1,j1,j2] - v[2]*B[j1,j2]
         EBv[2] = E[2,j1,j2] + v[1]*B[j1,j2]
-        vi[:] += EBv * ws
+        vi += EBv * ws
       end
     end
-    return vi[:]
+    return vi
   else
     error("Not yet implemented for D=$D")
   end

--- a/aux_functions/aux_functions_Interpolate.jl
+++ b/aux_functions/aux_functions_Interpolate.jl
@@ -179,3 +179,31 @@ end
   end
 end
 
+function Interpolate_All_EBv_1_slim(::Val{Order}, E::Array{Float64,3}, B::Matrix{Float64}, v::Matrix{Float64}, idx, y , J::NTuple, Box::NTuple) where {Order}
+  stencil = Int64(ceil((Order+1)/2))
+  D = length(J)
+  val_order = Val(Order)
+
+  if D==2
+    vi = zeros(Float64, N, 2)
+    @threads for i in 1:N
+      @inbounds for m in (-stencil):(stencil +1)
+        w2 = W(val_order, -y[i,2] + m)
+        idx2 = mod1(idx[i,2]+m,J[2])
+        @inbounds for l in (-stencil):(stencil +1)
+          w1 = W(val_order, -y[i,1] + l)
+          ws = w2 * w1
+          idx1 = mod1(idx[i,1]+l,J[1])
+
+          EBv1 = E[1,idx1,idx2] - v[i,2]*B[idx1,idx2]
+          EBv2 = E[2,idx1,idx2] + v[i,1]*B[idx1,idx2]
+          vi[i, 1] += EBv1 * ws
+          vi[i, 2] += EBv2 * ws
+        end
+      end
+    end
+    return vi
+  else
+    error("Not yet implemented for D=$D")
+  end
+end

--- a/aux_functions/aux_functions_RHS.jl
+++ b/aux_functions/aux_functions_RHS.jl
@@ -166,7 +166,6 @@ function RHS_D_slim(::Val{Order},u,t,p_RHSC) where {Order} #version to optimize
         @inbounds du[range_x(i, D)] = v[i,:] # relativistic factor (u is the momentum)
         @inbounds du[i*2D-D+1:i*2D] = - Interpolate_EBv_1_slim(Val(Order), E, B, v[i,:], idx[i,:], y[i,:], J, Box)
       end
-      return du[:]
   end
 
   function RHS_D_opt(u,t,p_RHSC) #version to optimize

--- a/aux_functions/aux_functions_RHS.jl
+++ b/aux_functions/aux_functions_RHS.jl
@@ -94,7 +94,7 @@ function RHS_D(u,t,p_RHSC)
     return du[:]
 end
 
-function RHS_D_slim(::Val{Order},u,t,p_RHSC) where {Order} #version to optimize
+function RHS_D_slim!(::Val{Order},u,t,p_RHSC) where {Order} #version to optimize
   N, J, Box, _, n, S, du, get_density!, get_current_threads, Interpolate,  Dx, Δx, σx, Dy, Δy, σy, maxwell, dissipation  = p_RHSC
   par_grid = (N, J, Box, Order)
   L = [(Box[2d] - Box[2d-1]) for d = 1:D]

--- a/aux_functions/aux_functions_RHS.jl
+++ b/aux_functions/aux_functions_RHS.jl
@@ -94,9 +94,9 @@ function RHS_D(u,t,p_RHSC)
     return du[:]
 end
 
-function RHS_D_slim(u,t,p_RHSC) #version to optimize
-  N, J, Box, order, n, S, du, get_density!, get_current_threads, Interpolate,  Dx, Δx, σx, Dy, Δy, σy, maxwell, dissipation  = p_RHSC
-  par_grid = (N, J, Box, order)
+function RHS_D_slim(::Val{Order},u,t,p_RHSC) where {Order} #version to optimize
+  N, J, Box, _, n, S, du, get_density!, get_current_threads, Interpolate,  Dx, Δx, σx, Dy, Δy, σy, maxwell, dissipation  = p_RHSC
+  par_grid = (N, J, Box, Order)
   L = [(Box[2d] - Box[2d-1]) for d = 1:D]
   make_periodic!(u,Box_x,N)
   #r = [u[(i-1)*2D+d] for i in 1:N, d in 1:D] # no se como hacerlo funcionar con threads
@@ -114,7 +114,7 @@ function RHS_D_slim(u,t,p_RHSC) #version to optimize
   get_indices_and_y_trans!(idx, y, r, J, L)
   v_trans!(Val(D), v, N, n0, u)
   # v is already divided by n0! So we don't need to divide again here.
-  S = get_current_slim(Val(order), Box_x, J, local_results, idx, y, v)
+  S = get_current_slim(Val(Order), Box_x, J, local_results, idx, y, v)
      
     
     Fu = view(u,4N+1:4N+3*prod(J))
@@ -164,7 +164,7 @@ function RHS_D_slim(u,t,p_RHSC) #version to optimize
         #@inbounds @views v = p2v(u[i*2D-D+1:i*2D])
         # v = p2v(u[range_p(i, D)])
         @inbounds du[range_x(i, D)] = v[i,:] # relativistic factor (u is the momentum)
-        @inbounds du[i*2D-D+1:i*2D] = - Interpolate_EBv_1_slim(order, E, B, v[i,:], idx[i,:], y[i,:], J, Box)
+        @inbounds du[i*2D-D+1:i*2D] = - Interpolate_EBv_1_slim(Val(Order), E, B, v[i,:], idx[i,:], y[i,:], J, Box)
       end
       return du[:]
   end

--- a/aux_functions/aux_functions_RHS.jl
+++ b/aux_functions/aux_functions_RHS.jl
@@ -160,11 +160,14 @@ function RHS_D_slim(::Val{Order},u,t,p_RHSC) where {Order} #version to optimize
         end
       end
 
-      @threads for i in 1:N        
+      interp = Interpolate_All_EBv_1_slim(Val(Order), E, B, v, idx, y, J, Box)
+      @threads for i in 1:N
         #@inbounds @views v = p2v(u[i*2D-D+1:i*2D])
         # v = p2v(u[range_p(i, D)])
-        @inbounds du[range_x(i, D)] = v[i,:] # relativistic factor (u is the momentum)
-        @inbounds du[i*2D-D+1:i*2D] = - Interpolate_EBv_1_slim(Val(Order), E, B, v[i,:], idx[i,:], y[i,:], J, Box)
+        for d in 1:D
+          @inbounds du[(i-1)*2D+d] = v[i,d] # relativistic factor (u is the momentum)
+          @inbounds du[i*2D-D+d] = -interp[i, d]
+        end
       end
   end
 


### PR DESCRIPTION
1. Hacer que Order siempre se pase como un tipo (e.g. `Val(Order)`).
2. `RHS_D_slim` modifica `du`, no necesita devolver una copia (y por eso se tiene que llamar `RHS_D_slim!` también).
3. Arreglar el bug de `ws` en `Interpolate_EBv_1_slim`.
4. Hacer que `Interpolate_EBv_1_slim` se llame una única vez y opere sobre todo en una pasada, sin tener que extraer `v`, `j` e `y` de las matrices de manera costosa en cada llamada.

